### PR TITLE
Exclude port from chatContainerStr

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -43,7 +43,7 @@ ${ns.rdf('seeAlso')} <${chatThing.value}> .
 function determineChatContainer (invitee, podRoot) {
   // Create chat
   // See https://gitter.im/solid/chat-app?at=5f3c800f855be416a23ae74a
-  const chatContainerStr = new URL(`IndividualChats/${new URL(invitee.value).host}/`, podRoot.value).toString()
+  const chatContainerStr = new URL(`IndividualChats/${new URL(invitee.value).hostname}/`, podRoot.value).toString()
   return new NamedNode(chatContainerStr)
 }
 


### PR DESCRIPTION
The port has no meaning in this context and will allow compatibility with Windows where colon are forbidden in file/folder names.
It has not impact on `solidcommunity.net` nor `inrupt.net`, or any of podProvider that do not use a specific port. 
see issue https://github.com/solid/solid-panes/issues/262